### PR TITLE
Raises text upper bound (<3)

### DIFF
--- a/servant-openapi3.cabal
+++ b/servant-openapi3.cabal
@@ -85,7 +85,7 @@ library
                      , servant                   >=0.17     && <0.20
                      , singleton-bool            >=0.1.4    && <0.2
                      , openapi3                  >=3.0.0    && <3.3
-                     , text                      >=1.2.3.0  && <1.3
+                     , text                      >=1.2.3.0  && <3
                      , unordered-containers      >=0.2.9.0  && <0.3
 
                      , hspec


### PR DESCRIPTION
Just what it says on the tin; the latest version of `text` is now `2.0`.