### PR TITLE
Add gen adapter parameter to validateEveryToJSON

### DIFF
--- a/src/Servant/OpenApi/Test.hs
+++ b/src/Servant/OpenApi/Test.hs
@@ -7,7 +7,9 @@
 -- Automatic tests for servant API against OpenApi spec.
 module Servant.OpenApi.Test (
   validateEveryToJSON,
+  validateEveryToJSON',
   validateEveryToJSONWithPatternChecker,
+  validateEveryToJSONWithPatternChecker',
 ) where
 
 import           Servant.OpenApi.Internal.Test


### PR DESCRIPTION
I am currently working with an API which can have very nested types with arrays.
So using the default `Arbitrary` instance make the tests very slow.
The solution is to call QuickCheck's `resize` function with a low number. After all we are only checking the shape of the data, its size shouldn't matter.

So in this PR I add `validateEveryToJSON'` and `validateEveryToJSONWithPatternChecker'` which allow to pass a function to adapt the generator.