### PR TITLE
Add an HasOpenApi instance for AuthProtect

### DIFF
--- a/src/Servant/OpenApi/Internal.hs
+++ b/src/Servant/OpenApi/Internal.hs
@@ -431,6 +431,11 @@ instance (HasOpenApi (ToServantApi sub)) => HasOpenApi (NamedRoutes sub) where
   toOpenApi _ = toOpenApi (Proxy :: Proxy (ToServantApi sub))
 #endif
 
+#if MIN_VERSION_servant(0,5,0)
+instance (HasOpenApi sub) => HasOpenApi (AuthProtect a :> sub) where
+  toOpenApi _ = toOpenApi (Proxy :: Proxy sub)
+#endif
+
 -- =======================================================================
 -- Below are the definitions that should be in Servant.API.ContentTypes
 -- =======================================================================


### PR DESCRIPTION
This is a dummy instance that does nothing.
The `securitySchemes` are top-level, so they cannot be defined/extracted here.

However, there could be an argument that this should add the `AuthProtect`'s symbol to all the nested routes' `security`... I'm unsure how to do that though.