### PR TITLE
add HasOpenAPi for RawM

### DIFF
--- a/src/Servant/OpenApi/Internal.hs
+++ b/src/Servant/OpenApi/Internal.hs
@@ -83,6 +83,11 @@ class HasOpenApi api where
 instance HasOpenApi Raw where
   toOpenApi _ = mempty & paths . at "/" ?~ mempty
 
+#if MIN_VERSION_servant(0,20,0)
+instance HasOpenApi RawM where
+  toOpenApi _ = mempty & paths . at "/" ?~ mempty
+#endif
+
 instance HasOpenApi EmptyAPI where
   toOpenApi _ = mempty
 


### PR DESCRIPTION
Servant recently added `RawM` in 0.20 which is similar to `Raw`.  This PR adds a `HasOpenApi` instance for `RawM`.