### PR TITLE
Allow base-compat-0.14

### DIFF
--- a/servant-openapi3.cabal
+++ b/servant-openapi3.cabal
@@ -80,7 +80,7 @@ library
   build-depends:       aeson                     >=1.4.2.0  && <1.6 || >=2.0.1.0 && <2.3
                      , aeson-pretty              >=0.8.7    && <0.9
                      , base                      >=4.9.1.0  && <4.20
-                     , base-compat               >=0.10.5   && <0.14
+                     , base-compat               >=0.10.5   && <0.15
                      , bytestring                >=0.10.8.1 && <0.13
                      , http-media                >=0.7.1.3  && <0.9
                      , insert-ordered-containers >=0.2.1.0  && <0.3


### PR DESCRIPTION
Tested using

    cabal build -w ghc-9.8.2 -c 'base-compat>=0.14' --allow-newer=servant-server:base-compat,openapi3:base-compat-batteries

The last allow-newer will be unnecessary after

* https://github.com/biocad/openapi3/pull/100