### PR TITLE
Set required attribute for request bodies

### DIFF
--- a/src/Servant/OpenApi.hs
+++ b/src/Servant/OpenApi.hs
@@ -157,7 +157,8 @@ import           Servant.OpenApi.Internal.Orphans ()
 --                                 "$ref": "#/components/schemas/User"
 --                             }
 --                         }
---                     }
+--                     },
+--                     "required": true
 --                 },
 --                 "responses": {
 --                     "200": {
@@ -288,7 +289,8 @@ import           Servant.OpenApi.Internal.Orphans ()
 --                                 "$ref": "#/components/schemas/User"
 --                             }
 --                         }
---                     }
+--                     },
+--                     "required": true
 --                 },
 --                 "responses": {
 --                     "200": {
@@ -420,7 +422,8 @@ import           Servant.OpenApi.Internal.Orphans ()
 --                                 "$ref": "#/components/schemas/User"
 --                             }
 --                         }
---                     }
+--                     },
+--                     "required": true
 --                 },
 --                 "responses": {
 --                     "200": {

--- a/src/Servant/OpenApi/Internal.hs
+++ b/src/Servant/OpenApi/Internal.hs
@@ -390,7 +390,7 @@ instance (KnownSymbol sym, ToParamSchema a, HasOpenApi sub, SBoolI (FoldRequired
         & in_ .~ ParamHeader
         & schema ?~ (Inline $ toParamSchema (Proxy :: Proxy a))
 
-instance (ToSchema a, AllAccept cs, HasOpenApi sub, KnownSymbol (FoldDescription mods)) => HasOpenApi (ReqBody' mods cs a :> sub) where
+instance (ToSchema a, AllAccept cs, HasOpenApi sub, KnownSymbol (FoldDescription mods), SBoolI (FoldRequired mods)) => HasOpenApi (ReqBody' mods cs a :> sub) where
   toOpenApi _ = toOpenApi (Proxy :: Proxy sub)
     & addRequestBody reqBody
     & addDefaultResponse400 tname
@@ -402,6 +402,7 @@ instance (ToSchema a, AllAccept cs, HasOpenApi sub, KnownSymbol (FoldDescription
       (defs, ref) = runDeclare (declareSchemaRef (Proxy :: Proxy a)) mempty
       reqBody = (mempty :: RequestBody)
         & description .~ transDesc (reflectDescription (Proxy :: Proxy mods))
+        & required .~ (if reflectBool (Proxy :: Proxy (FoldRequired mods)) then Just True else Nothing)
         & content .~ InsOrdHashMap.fromList [(t, mempty & schema ?~ ref) | t <- allContentType (Proxy :: Proxy cs)]
 
 -- | This instance is an approximation.


### PR DESCRIPTION
While not generally necessary for documentation, setting the request body to required does help with some client code generation (e.g. the body type generated by openapi-typescript will be required).