### PR TITLE
Support for MultiVerb

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -205,6 +205,29 @@ jobs:
           echo "package example" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
+          source-repository-package
+            type:     git
+            location: https://github.com/haskell-servant/servant
+            tag:      servant-0.20.3.0
+            subdir:   ./servant
+
+          source-repository-package
+            type:     git
+            location: https://github.com/haskell-servant/servant
+            tag:      servant-0.20.3.0
+            subdir:   ./servant-server
+
+          source-repository-package
+            type:     git
+            location: https://github.com/haskell-servant/servant
+            tag:      servant-0.20.3.0
+            subdir:   ./servant-client
+
+          source-repository-package
+            type:     git
+            location: https://github.com/haskell-servant/servant
+            tag:      servant-0.20.3.0
+            subdir:   ./servant-client-core
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(example|servant-openapi3)$/; }' >> cabal.project.local
           cat cabal.project

--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,13 @@ packages:
     servant-openapi3.cabal,
     example/example.cabal
 tests: true
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell-servant/servant
+  tag: servant-0.20.3.0
+  subdir:
+    ./servant
+    ./servant-server
+    ./servant-client
+    ./servant-client-core

--- a/cabal.project
+++ b/cabal.project
@@ -2,13 +2,3 @@ packages:
     servant-openapi3.cabal,
     example/example.cabal
 tests: true
-
-source-repository-package
-  type: git
-  location: https://github.com/haskell-servant/servant
-  tag: servant-0.20.3.0
-  subdir:
-    ./servant
-    ./servant-server
-    ./servant-client
-    ./servant-client-core

--- a/example/example.cabal
+++ b/example/example.cabal
@@ -41,6 +41,7 @@ library
                 , openapi3
                 , text
                 , time
+                , generics-sop
   default-language: Haskell2010
 
 executable swagger-server

--- a/example/src/Todo.hs
+++ b/example/src/Todo.hs
@@ -32,6 +32,7 @@ type TodoAPI
  :<|> "todo" :> Capture "id" TodoId :> Get '[JSON] Todo
  :<|> "todo" :> Capture "id" TodoId :> ReqBody '[JSON] Todo :> Put '[JSON] TodoId
  :<|> "todo" :> "choices" :> MultipleChoicesInt
+ 
 -- | API for serving @swagger.json@.
 type SwaggerAPI = "swagger.json" :> Get '[JSON] OpenApi
 

--- a/example/swagger.json
+++ b/example/swagger.json
@@ -1,165 +1,204 @@
 {
-    "openapi": "3.0.0",
-    "info": {
-        "version": "1.0",
-        "title": "Todo API",
-        "license": {
-            "url": "http://mit.com",
-            "name": "MIT"
+  "components": {
+    "schemas": {
+      "Todo": {
+        "description": "This is some real Todo right here",
+        "example": {
+          "created": "2015-12-31T00:00:00Z",
+          "summary": "get milk"
         },
-        "description": "This is an API that tests swagger integration"
-    },
-    "paths": {
-        "/todo": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json;charset=utf-8": {
-                                "schema": {
-                                    "items": {
-                                        "$ref": "#/components/schemas/Todo"
-                                    },
-                                    "type": "array"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json;charset=utf-8": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Todo"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "400": {
-                        "description": "Invalid `body`"
-                    },
-                    "200": {
-                        "content": {
-                            "application/json;charset=utf-8": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TodoId"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
+        "properties": {
+          "created": {
+            "$ref": "#/components/schemas/UTCTime"
+          },
+          "summary": {
+            "type": "string"
+          }
         },
-        "/todo/{id}": {
-            "get": {
-                "parameters": [
-                    {
-                        "required": true,
-                        "schema": {
-                            "maximum": 9223372036854775807,
-                            "minimum": -9223372036854775808,
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "name": "id"
-                    }
-                ],
-                "responses": {
-                    "404": {
-                        "description": "`id` not found"
-                    },
-                    "200": {
-                        "content": {
-                            "application/json;charset=utf-8": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Todo"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            },
-            "put": {
-                "parameters": [
-                    {
-                        "required": true,
-                        "schema": {
-                            "maximum": 9223372036854775807,
-                            "minimum": -9223372036854775808,
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "name": "id"
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json;charset=utf-8": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Todo"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "404": {
-                        "description": "`id` not found"
-                    },
-                    "400": {
-                        "description": "Invalid `body`"
-                    },
-                    "200": {
-                        "content": {
-                            "application/json;charset=utf-8": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TodoId"
-                                }
-                            }
-                        },
-                        "description": ""
-                    }
-                }
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Todo": {
-                "example": {
-                    "summary": "get milk",
-                    "created": "2015-12-31T00:00:00Z"
-                },
-                "required": [
-                    "created",
-                    "summary"
-                ],
-                "type": "object",
-                "description": "This is some real Todo right here",
-                "properties": {
-                    "summary": {
-                        "type": "string"
-                    },
-                    "created": {
-                        "$ref": "#/components/schemas/UTCTime"
-                    }
-                }
-            },
-            "UTCTime": {
-                "example": "2016-07-22T00:00:00Z",
-                "format": "yyyy-mm-ddThh:MM:ssZ",
-                "type": "string"
-            },
-            "TodoId": {
-                "maximum": 9223372036854775807,
-                "minimum": -9223372036854775808,
-                "type": "integer"
-            }
-        }
+        "required": [
+          "created",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "TodoId": {
+        "maximum": 9223372036854775807,
+        "minimum": -9223372036854775808,
+        "type": "integer"
+      },
+      "UTCTime": {
+        "example": "2016-07-22T00:00:00Z",
+        "format": "yyyy-mm-ddThh:MM:ssZ",
+        "type": "string"
+      }
     }
+  },
+  "info": {
+    "description": "This is an API that tests swagger integration",
+    "license": {
+      "name": "MIT",
+      "url": "http://mit.com"
+    },
+    "title": "Todo API",
+    "version": "1.0"
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/todo": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json;charset=utf-8": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Todo"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json;charset=utf-8": {
+              "schema": {
+                "$ref": "#/components/schemas/Todo"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json;charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/TodoId"
+                }
+              }
+            },
+            "description": ""
+          },
+          "400": {
+            "description": "Invalid `body`"
+          }
+        }
+      }
+    },
+    "/todo/choices/{int}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "int",
+            "required": true,
+            "schema": {
+              "maximum": 9223372036854775807,
+              "minimum": -9223372036854775808,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              },
+              "application/json;charset=utf-8": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "description": "Even number\n\nOdd number"
+          },
+          "400": {
+            "description": "Negative"
+          },
+          "404": {
+            "description": "`int` not found"
+          }
+        }
+      }
+    },
+    "/todo/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "maximum": 9223372036854775807,
+              "minimum": -9223372036854775808,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json;charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/Todo"
+                }
+              }
+            },
+            "description": ""
+          },
+          "404": {
+            "description": "`id` not found"
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "maximum": 9223372036854775807,
+              "minimum": -9223372036854775808,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json;charset=utf-8": {
+              "schema": {
+                "$ref": "#/components/schemas/Todo"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json;charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/TodoId"
+                }
+              }
+            },
+            "description": ""
+          },
+          "400": {
+            "description": "Invalid `body`"
+          },
+          "404": {
+            "description": "`id` not found"
+          }
+        }
+      }
+    }
+  }
 }

--- a/example/swagger.json
+++ b/example/swagger.json
@@ -1,204 +1,204 @@
 {
-  "components": {
-    "schemas": {
-      "Todo": {
-        "description": "This is some real Todo right here",
-        "example": {
-          "created": "2015-12-31T00:00:00Z",
-          "summary": "get milk"
+    "components": {
+        "schemas": {
+            "Todo": {
+                "description": "This is some real Todo right here",
+                "example": {
+                    "created": "2015-12-31T00:00:00Z",
+                    "summary": "get milk"
+                },
+                "properties": {
+                    "created": {
+                        "$ref": "#/components/schemas/UTCTime"
+                    },
+                    "summary": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "created",
+                    "summary"
+                ],
+                "type": "object"
+            },
+            "TodoId": {
+                "maximum": 9223372036854775807,
+                "minimum": -9223372036854775808,
+                "type": "integer"
+            },
+            "UTCTime": {
+                "example": "2016-07-22T00:00:00Z",
+                "format": "yyyy-mm-ddThh:MM:ssZ",
+                "type": "string"
+            }
+        }
+    },
+    "info": {
+        "description": "This is an API that tests swagger integration",
+        "license": {
+            "name": "MIT",
+            "url": "http://mit.com"
         },
-        "properties": {
-          "created": {
-            "$ref": "#/components/schemas/UTCTime"
-          },
-          "summary": {
-            "type": "string"
-          }
+        "title": "Todo API",
+        "version": "1.0"
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/todo": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json;charset=utf-8": {
+                                "schema": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/Todo"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json;charset=utf-8": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Todo"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json;charset=utf-8": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TodoId"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "description": "Invalid `body`"
+                    }
+                }
+            }
         },
-        "required": [
-          "created",
-          "summary"
-        ],
-        "type": "object"
-      },
-      "TodoId": {
-        "maximum": 9223372036854775807,
-        "minimum": -9223372036854775808,
-        "type": "integer"
-      },
-      "UTCTime": {
-        "example": "2016-07-22T00:00:00Z",
-        "format": "yyyy-mm-ddThh:MM:ssZ",
-        "type": "string"
-      }
+        "/todo/choices/{int}": {
+            "get": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "int",
+                        "required": true,
+                        "schema": {
+                            "maximum": 9223372036854775807,
+                            "minimum": -9223372036854775808,
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "application/json;charset=utf-8": {
+                                "schema": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "description": "Even number\n\nOdd number"
+                    },
+                    "400": {
+                        "description": "Negative"
+                    },
+                    "404": {
+                        "description": "`int` not found"
+                    }
+                }
+            }
+        },
+        "/todo/{id}": {
+            "get": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "maximum": 9223372036854775807,
+                            "minimum": -9223372036854775808,
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json;charset=utf-8": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Todo"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "description": "`id` not found"
+                    }
+                }
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "maximum": 9223372036854775807,
+                            "minimum": -9223372036854775808,
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json;charset=utf-8": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Todo"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json;charset=utf-8": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TodoId"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "description": "Invalid `body`"
+                    },
+                    "404": {
+                        "description": "`id` not found"
+                    }
+                }
+            }
+        }
     }
-  },
-  "info": {
-    "description": "This is an API that tests swagger integration",
-    "license": {
-      "name": "MIT",
-      "url": "http://mit.com"
-    },
-    "title": "Todo API",
-    "version": "1.0"
-  },
-  "openapi": "3.0.0",
-  "paths": {
-    "/todo": {
-      "get": {
-        "responses": {
-          "200": {
-            "content": {
-              "application/json;charset=utf-8": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/Todo"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": ""
-          }
-        }
-      },
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json;charset=utf-8": {
-              "schema": {
-                "$ref": "#/components/schemas/Todo"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json;charset=utf-8": {
-                "schema": {
-                  "$ref": "#/components/schemas/TodoId"
-                }
-              }
-            },
-            "description": ""
-          },
-          "400": {
-            "description": "Invalid `body`"
-          }
-        }
-      }
-    },
-    "/todo/choices/{int}": {
-      "get": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "int",
-            "required": true,
-            "schema": {
-              "maximum": 9223372036854775807,
-              "minimum": -9223372036854775808,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              },
-              "application/json;charset=utf-8": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            },
-            "description": "Even number\n\nOdd number"
-          },
-          "400": {
-            "description": "Negative"
-          },
-          "404": {
-            "description": "`int` not found"
-          }
-        }
-      }
-    },
-    "/todo/{id}": {
-      "get": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "maximum": 9223372036854775807,
-              "minimum": -9223372036854775808,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json;charset=utf-8": {
-                "schema": {
-                  "$ref": "#/components/schemas/Todo"
-                }
-              }
-            },
-            "description": ""
-          },
-          "404": {
-            "description": "`id` not found"
-          }
-        }
-      },
-      "put": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "maximum": 9223372036854775807,
-              "minimum": -9223372036854775808,
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json;charset=utf-8": {
-              "schema": {
-                "$ref": "#/components/schemas/Todo"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json;charset=utf-8": {
-                "schema": {
-                  "$ref": "#/components/schemas/TodoId"
-                }
-              }
-            },
-            "description": ""
-          },
-          "400": {
-            "description": "Invalid `body`"
-          },
-          "404": {
-            "description": "`id` not found"
-          }
-        }
-      }
-    }
-  }
 }

--- a/servant-openapi3.cabal
+++ b/servant-openapi3.cabal
@@ -88,10 +88,13 @@ library
                      , insert-ordered-containers >=0.2.1.0  && <0.3
                      , lens                      >=4.17     && <5.4
                      , servant                   >=0.17     && <0.21
+                     , servant-server            >=0.17     && <0.21
+                     , servant-client-core       >=0.17     && <0.21
                      , singleton-bool            >=0.1.4    && <0.2
                      , openapi3                  >=3.2.3    && <3.3
                      , text                      >=1.2.3.0  && <3
                      , unordered-containers      >=0.2.9.0  && <0.3
+                     , generics-sop              >=0.5.1
 
                      , hspec
                      , QuickCheck

--- a/src/Servant/OpenApi/Internal.hs
+++ b/src/Servant/OpenApi/Internal.hs
@@ -469,6 +469,7 @@ instance (ToResponseHeader h, AllToResponseHeader hs) => AllToResponseHeader (h 
 instance AllToResponseHeader hs => AllToResponseHeader (HList hs) where
   toAllResponseHeaders _ = toAllResponseHeaders (Proxy :: Proxy hs)
 
+#if MIN_VERSION_servant(0,20,3)
 type DeclareDefinition = Declare (Definitions Schema)
 
 class IsSwaggerResponse a where
@@ -620,3 +621,4 @@ instance
               . List.listToMaybe
               . toList
       refResps = Inline . addMime <$> resps
+#endif

--- a/src/Servant/OpenApi/Internal.hs
+++ b/src/Servant/OpenApi/Internal.hs
@@ -39,10 +39,12 @@ import           Servant.API
 import           Servant.API.Description    (FoldDescription, reflectDescription)
 import           Servant.API.Modifiers      (FoldRequired)
 import           Servant.OpenApi.Internal.TypeLevel.API
-import           Servant.API.MultiVerb
 import           Data.Kind (Type)
 import           Servant.API.ContentTypes (AllMime, allMime)
+#if MIN_VERSION_servant(0,20,3)
 import qualified Servant.Server.Internal.ResponseRender as Server
+import           Servant.API.MultiVerb
+#endif
 import qualified Data.Maybe as List
 
 -- | Generate a OpenApi specification for a servant API.

--- a/src/Servant/OpenApi/Internal.hs
+++ b/src/Servant/OpenApi/Internal.hs
@@ -482,7 +482,7 @@ instance
       (headers .~ fmap Inline (toAllResponseHeaders (Proxy @hs)))
       (responseSwagger @r)
 
-class IsSwaggerResponseList as where
+class IsSwaggerResponseList (as :: [Type]) where
   responseListSwagger :: DeclareDefinition (InsOrdHashMap HttpStatusCode Response)
 
 class IsSwaggerResponse a where

--- a/src/Servant/OpenApi/Internal.hs
+++ b/src/Servant/OpenApi/Internal.hs
@@ -1,15 +1,19 @@
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE ConstraintKinds      #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 #if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableInstances  #-}
 #endif
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Servant.OpenApi.Internal where
@@ -17,9 +21,7 @@ module Servant.OpenApi.Internal where
 import Prelude ()
 import Prelude.Compat
 
-#if MIN_VERSION_servant(0,18,1)
-import           Control.Applicative                    ((<|>))
-#endif
+import           Control.Applicative        ((<|>))
 import           Control.Lens
 import           Data.Aeson
 import           Data.Foldable              (toList)
@@ -38,11 +40,12 @@ import           Network.HTTP.Media         (MediaType)
 import           Servant.API
 import           Servant.API.Description    (FoldDescription, reflectDescription)
 import           Servant.API.Modifiers      (FoldRequired)
-#if MIN_VERSION_servant(0,19,0)
-import           Servant.API.Generic        (ToServantApi)
-#endif
-
 import           Servant.OpenApi.Internal.TypeLevel.API
+import           Servant.API.MultiVerb
+import           Data.Kind (Type)
+import           Servant.API.ContentTypes (AllMime, allMime)
+import qualified Servant.Server.Internal.ResponseRender as Server
+import qualified Data.Maybe as List
 
 -- | Generate a OpenApi specification for a servant API.
 --
@@ -467,3 +470,155 @@ instance (ToResponseHeader h, AllToResponseHeader hs) => AllToResponseHeader (h 
 
 instance AllToResponseHeader hs => AllToResponseHeader (HList hs) where
   toAllResponseHeaders _ = toAllResponseHeaders (Proxy :: Proxy hs)
+
+type DeclareDefinition = Declare (Definitions Schema)
+
+instance
+  (AllToResponseHeader hs, IsSwaggerResponse r) =>
+  IsSwaggerResponse (WithHeaders hs a r)
+  where
+  responseSwagger =
+    fmap
+      (headers .~ fmap Inline (toAllResponseHeaders (Proxy @hs)))
+      (responseSwagger @r)
+
+class IsSwaggerResponseList as where
+  responseListSwagger :: DeclareDefinition (InsOrdHashMap HttpStatusCode Response)
+
+class IsSwaggerResponse a where
+  responseSwagger :: DeclareDefinition Response
+
+simpleResponseSwagger :: forall a cs desc. (ToSchema a, KnownSymbol desc, AllMime cs) => DeclareDefinition Response
+simpleResponseSwagger = do
+  ref <- declareSchemaRef (Proxy @a)
+  let resps :: InsOrdHashMap MediaType MediaTypeObject
+      resps = InsOrdHashMap.fromList $ (,MediaTypeObject (pure ref) Nothing mempty mempty) <$> cs
+  pure $
+    mempty
+      & description .~ Text.pack (symbolVal (Proxy @desc))
+      & content .~ resps
+  where
+    cs :: [MediaType]
+    cs = allMime $ Proxy @cs
+
+instance
+  (KnownSymbol desc, ToSchema a) =>
+  IsSwaggerResponse (Respond s desc a)
+  where
+  -- Defaulting this to JSON, as openapi3 needs something to map a schema against.
+  responseSwagger = simpleResponseSwagger @a @'[JSON] @desc
+
+instance IsSwaggerResponseList '[] where
+  responseListSwagger = pure mempty
+
+instance
+  (KnownSymbol desc, ToSchema a, Accept ct) =>
+  IsSwaggerResponse (RespondAs (ct :: Type) s desc a)
+  where
+  responseSwagger = simpleResponseSwagger @a @'[ct] @desc
+
+instance
+  (KnownSymbol desc) =>
+  IsSwaggerResponse (RespondEmpty s desc)
+  where
+  responseSwagger =
+    pure $
+      mempty
+        & description .~ Text.pack (symbolVal (Proxy @desc))
+
+instance
+  ( IsSwaggerResponse a,
+    KnownNat (Server.ResponseStatus a),
+    IsSwaggerResponseList as
+  ) =>
+  IsSwaggerResponseList (a ': as)
+  where
+  responseListSwagger =
+    InsOrdHashMap.insertWith
+      combineResponseSwagger
+      (fromIntegral (natVal (Proxy @(Server.ResponseStatus a))))
+      <$> responseSwagger @a
+      <*> responseListSwagger @as
+
+combineResponseSwagger :: Response -> Response -> Response
+combineResponseSwagger r1 r2 =
+  r1
+    & description <>~ ("\n\n" <> r2 ^. description)
+    & content %~ flip (InsOrdHashMap.unionWith combineMediaTypeObject) (r2 ^. content)
+
+combineMediaTypeObject :: MediaTypeObject -> MediaTypeObject -> MediaTypeObject
+combineMediaTypeObject m1 m2 =
+  m1 & schema .~ merge (m1 ^. schema) (m2 ^. schema)
+  where
+    merge Nothing a = a
+    merge a Nothing = a
+    merge (Just (Inline a)) (Just (Inline b)) = pure $ Inline $ combineSwaggerSchema a b
+    merge a@(Just (Ref _)) _ = a
+    merge _ a@(Just (Ref _)) = a
+
+combineSwaggerSchema :: Schema -> Schema -> Schema
+combineSwaggerSchema s1 s2
+  -- if they are both errors, merge label enums
+  | notNullOf (properties . ix "code") s1
+      && notNullOf (properties . ix "code") s2 =
+      s1
+        & properties . ix "label" . _Inline . enum_ . _Just
+          <>~ (s2 ^. properties . ix "label" . _Inline . enum_ . _Just)
+  | otherwise = s1
+
+instance
+  (OpenApiMethod method, IsSwaggerResponseList as) =>
+  HasOpenApi (MultiVerb method '() as r)
+  where
+  toOpenApi _ =
+    mempty
+      & components . schemas <>~ defs
+      & paths
+        . at "/"
+        ?~ ( mempty
+               & method
+                 ?~ ( mempty
+                        & responses . responses .~ refResps
+                    )
+           )
+    where
+      method = openApiMethod (Proxy @method)
+      (defs, resps) = runDeclare (responseListSwagger @as) mempty
+      refResps = Inline <$> resps
+
+instance
+  (OpenApiMethod method, IsSwaggerResponseList as, AllMime cs) =>
+  HasOpenApi (MultiVerb method (cs :: [Type]) as r)
+  where
+  toOpenApi _ =
+    mempty
+      & components . schemas <>~ defs
+      & paths
+        . at "/"
+        ?~ ( mempty
+               & method
+                 ?~ ( mempty
+                        & responses . responses .~ refResps
+                    )
+           )
+    where
+      method = openApiMethod (Proxy @method)
+      -- This has our content types.
+      cs = allMime (Proxy @cs)
+      -- This has our schemas
+      (defs, resps) = runDeclare (responseListSwagger @as) mempty
+      -- We need to zip them together, and stick it all back into the contentMap
+      -- Since we have a single schema per type, and are only changing the content-types,
+      -- we should be able to pick a schema out of the resps' map, and then use it for
+      -- all of the values of cs
+      addMime :: Response -> Response
+      addMime resp =
+        resp
+          & content
+            %~
+            -- pick out an element from the map, if any exist.
+            -- These will all have the same schemas, and we are reapplying the content types.
+            foldMap (\c -> InsOrdHashMap.fromList $ (,c) <$> cs)
+              . List.listToMaybe
+              . toList
+      refResps = Inline . addMime <$> resps

--- a/src/Servant/OpenApi/Internal/TypeLevel/API.hs
+++ b/src/Servant/OpenApi/Internal/TypeLevel/API.hs
@@ -13,6 +13,9 @@ import           Servant.API
 #if MIN_VERSION_servant(0,19,0)
 import           Servant.API.Generic (ToServantApi)
 #endif
++#if MIN_VERSION_servant(0,20,3)
++import Servant.API.MultiVerb (MultiVerb, ResponseTypes)
++#endif
 
 -- | Build a list of endpoints from an API.
 type family EndpointsList api where
@@ -89,6 +92,9 @@ type family BodyTypes' c api :: [*] where
   BodyTypes' c (Verb verb b cs (Headers hdrs a)) = AddBodyType c cs a '[]
   BodyTypes' c (Verb verb b cs NoContent) = '[]
   BodyTypes' c (Verb verb b cs a) = AddBodyType c cs a '[]
++#if MIN_VERSION_servant(0,20,3)
++  BodyTypes' c (MultiVerb verb cs as _) = AddBodyType c cs () (ResponseTypes as)
++#endif
   BodyTypes' c (ReqBody' mods cs a :> api) = AddBodyType c cs a (BodyTypes' c api)
   BodyTypes' c (e :> api) = BodyTypes' c api
   BodyTypes' c (a :<|> b) = AppendList (BodyTypes' c a) (BodyTypes' c b)


### PR DESCRIPTION
This commit brings support for MultiVerb, introduced in servant-0.20.3.0.
The cabal.project file is used to depend on the pre-release.
![todo-choices](https://github.com/user-attachments/assets/8574df81-d3a2-45e1-b437-0ab438b7c3af)

